### PR TITLE
Add curios slot for tanks

### DIFF
--- a/src/main/java/com/rae/creatingspace/client/gui/RemainingO2Overlay.java
+++ b/src/main/java/com/rae/creatingspace/client/gui/RemainingO2Overlay.java
@@ -8,7 +8,6 @@ import com.rae.creatingspace.server.armor.OxygenBacktankUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.client.gui.overlay.ForgeGui;
@@ -29,16 +28,16 @@ public class RemainingO2Overlay implements IGuiOverlay {
         if (player == null)
             return;
 
-        ItemStack itemInChestSlot = player.getItemBySlot(EquipmentSlot.CHEST);
+        ItemStack tank = OxygenBacktankItem.getWornByItem(player);
 
-        if (itemInChestSlot.getItem() instanceof OxygenBacktankItem){
-            CompoundTag tag = itemInChestSlot.getOrCreateTag();
+        if (tank != null){
+            CompoundTag tag = tank.getOrCreateTag();
             float o2Value = tag.getFloat("Oxygen");
             float prevO2Value =  tag.getFloat("prevOxygen");
             //prevO2Value = o2Value;
             //TODO create one at initialization the keep the same
             gauge = new SliderWidget(CSConfigs.CLIENT.oxygenBacktank.sliderPlace.get().getX(screenWidth), CSConfigs.CLIENT.oxygenBacktank.sliderPlace.get().getY(screenHeight), 32, 64, CSConfigs.CLIENT.oxygenBacktank.sliderColor.get().getColor());
-            gauge.setMax(OxygenBacktankUtil.maxOxygen(itemInChestSlot));
+            gauge.setMax(OxygenBacktankUtil.maxOxygen(tank));
             gauge.setValues((int) o2Value, (int) prevO2Value);
             gauge.render(poseStack, (int) mc.mouseHandler.xpos(),(int) mc.mouseHandler.ypos() ,partialTick);
 

--- a/src/main/java/com/rae/creatingspace/init/MiscInit.java
+++ b/src/main/java/com/rae/creatingspace/init/MiscInit.java
@@ -4,12 +4,14 @@ import com.rae.creatingspace.CreatingSpace;
 import com.rae.creatingspace.api.design.ExhaustPackType;
 import com.rae.creatingspace.api.design.PowerPackType;
 import com.rae.creatingspace.api.planets.RocketAccessibleDimension;
+import com.rae.creatingspace.server.armor.OxygenBacktankCurios;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.IForgeRegistry;
@@ -78,6 +80,9 @@ public class MiscInit {
         DEFERRED_EXHAUST_PACK_TYPE.register(modEventBus);
         DEFERRED_POWER_PACK_TYPE.register(modEventBus);
         DEFERRED_ROCKET_ACCESSIBLE_DIMENSION.register(modEventBus);
+
+        IEventBus forgeEventBus = MinecraftForge.EVENT_BUS;
+        OxygenBacktankCurios.init(modEventBus, forgeEventBus);
     }
 
 }

--- a/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankCurios.java
+++ b/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankCurios.java
@@ -1,0 +1,29 @@
+package com.rae.creatingspace.server.armor;
+
+import com.rae.creatingspace.server.armor.OxygenBacktankItem;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.SlotTypeMessage;
+import top.theillusivec4.curios.api.SlotTypePreset;
+
+public class OxygenBacktankCurios {
+    public static void init(IEventBus modEventBus, IEventBus forgeEventBus) {
+        modEventBus.addListener(OxygenBacktankCurios::onInterModEnqueue);
+        modEventBus.addListener(OxygenBacktankCurios::onClientSetup);
+    }
+
+    private static void onInterModEnqueue(final InterModEnqueueEvent event) {
+        InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.BACK.getMessageBuilder()
+                .build());
+    }
+
+    private static void onClientSetup(final FMLClientSetupEvent event) {
+        // TODO
+    }
+}

--- a/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankItem.java
+++ b/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankItem.java
@@ -10,11 +10,14 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
 import java.util.Locale;
 import java.util.function.Supplier;
@@ -44,14 +47,42 @@ public class OxygenBacktankItem extends UpgradableEquipment {
     }
 
     @Nullable
-    public static OxygenBacktankItem getWornBy(Entity entity) {
+    public static ItemStack getWornByItem(Entity entity) {
         if (!(entity instanceof LivingEntity livingEntity)) {
             return null;
         }
-        if (!(livingEntity.getItemBySlot(SLOT).getItem() instanceof OxygenBacktankItem item)) {
-            return null;
+
+        // armor slot
+        if ((livingEntity.getItemBySlot(SLOT).getItem() instanceof OxygenBacktankItem)) {
+            return livingEntity.getItemBySlot(SLOT);
         }
-        return item;
+
+        // curios slot
+        if (entity instanceof Player) {
+            return entity.getCapability(CuriosCapability.INVENTORY)
+                    .resolve().map(handler -> {
+                        ICurioStacksHandler stacksHandler = handler.getCurios().get("back");
+                        if (stacksHandler != null) {
+                            int slots = stacksHandler.getSlots();
+                            for (int slot = 0; slot < slots; slot++) {
+                                ItemStack item = stacksHandler.getStacks().getStackInSlot(slot);
+                                if (item.getItem() instanceof OxygenBacktankItem) {
+                                    return item;
+                                }
+                            }
+                        }
+                        return null;
+                    })
+                    .orElse(null);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    public static OxygenBacktankItem getWornBy(Entity entity) {
+        ItemStack item = getWornByItem(entity);
+        return item != null ? (OxygenBacktankItem) item.getItem() : null;
     }
 
     @Override

--- a/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankUtil.java
+++ b/src/main/java/com/rae/creatingspace/server/armor/OxygenBacktankUtil.java
@@ -14,7 +14,10 @@ import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +35,22 @@ public class OxygenBacktankUtil {
 				if (TagsInit.CustomItemTags.OXYGEN_SOURCES.matches(itemStack)) {
 					stacks.add(itemStack);
 				}
+
+			if (entity instanceof Player) {
+				entity.getCapability(CuriosCapability.INVENTORY)
+					.ifPresent(handler -> {
+						ICurioStacksHandler stacksHandler = handler.getCurios().get("back");
+						if (stacksHandler != null) {
+							int slots = stacksHandler.getSlots();
+							for (int slot = 0; slot < slots; slot++) {
+								ItemStack item = stacksHandler.getStacks().getStackInSlot(slot);
+								if (item.getItem() instanceof OxygenBacktankItem) {
+									stacks.add(item);
+								}
+							}
+						}
+					});
+			}
 
 			return stacks;
 		});

--- a/src/main/java/com/rae/creatingspace/server/event/CSEventHandler.java
+++ b/src/main/java/com/rae/creatingspace/server/event/CSEventHandler.java
@@ -4,6 +4,7 @@ import com.rae.creatingspace.CreatingSpace;
 import com.rae.creatingspace.init.DamageSourceInit;
 import com.rae.creatingspace.init.TagsInit;
 import com.rae.creatingspace.saved.DesignCommands;
+import com.rae.creatingspace.server.armor.OxygenBacktankItem;
 import com.rae.creatingspace.server.armor.OxygenBacktankUtil;
 import com.rae.creatingspace.server.blocks.atmosphere.OxygenBlock;
 import com.rae.creatingspace.server.entities.RoomAtmosphere;
@@ -74,7 +75,7 @@ public class CSEventHandler {
                 if (entityLiving instanceof ServerPlayer player)  {
                     if (playerNeedEquipment(player)) {
                         if (checkPlayerO2Equipment(player)) {
-                            ItemStack tank = player.getItemBySlot(EquipmentSlot.CHEST);
+                            ItemStack tank = OxygenBacktankItem.getWornByItem(player);
                             OxygenBacktankUtil.consumeOxygen(player, tank, 1);
                         } else {
                             player.hurt(DamageSourceInit.NO_OXYGEN, 0.5f);
@@ -107,13 +108,13 @@ public class CSEventHandler {
 
     public static boolean checkPlayerO2Equipment(ServerPlayer player){
 
-        ItemStack chestPlate = player.getItemBySlot(EquipmentSlot.CHEST);
+        ItemStack tank = OxygenBacktankItem.getWornByItem(player);
         ItemStack helmet = player.getItemBySlot(EquipmentSlot.HEAD);
         ItemStack leggings = player.getItemBySlot(EquipmentSlot.LEGS);
         ItemStack boots =  player.getItemBySlot(EquipmentSlot.FEET);
 
-        if (TagsInit.CustomItemTags.OXYGEN_SOURCES.matches(chestPlate) && OxygenBacktankUtil.hasOxygenRemaining(chestPlate)){
-            return TagsInit.CustomItemTags.SPACESUIT.matches(chestPlate)&&
+        if (tank != null && TagsInit.CustomItemTags.OXYGEN_SOURCES.matches(tank) && OxygenBacktankUtil.hasOxygenRemaining(tank)) {
+            return TagsInit.CustomItemTags.SPACESUIT.matches(tank)&&
                     TagsInit.CustomItemTags.SPACESUIT.matches(helmet)&&
                     TagsInit.CustomItemTags.SPACESUIT.matches(leggings)&&
                     TagsInit.CustomItemTags.SPACESUIT.matches(boots);

--- a/src/main/resources/data/curios/tags/items/back.json
+++ b/src/main/resources/data/curios/tags/items/back.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "creatingspace:copper_oxygen_backtank",
+    "creatingspace:netherite_oxygen_backtank"
+  ]
+}


### PR DESCRIPTION
Now oxygen backtanks can be equipped in the extra back slot of curios api. 

ideally the backtank and the spacesuite should be different item that can be optionally combined, so you can have the tank in the slot and the chestplate as normal. or I guess the tank slot could be an extra oxygen supply