### PR TITLE
Fix a Ponder issue.

### DIFF
--- a/src/main/java/com/rae/creatingspace/content/ponders/CSPonderPlugin.java
+++ b/src/main/java/com/rae/creatingspace/content/ponders/CSPonderPlugin.java
@@ -6,7 +6,6 @@ import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.kinetics.crank.ValveHandleBlock;
 import com.simibubi.create.content.logistics.packagePort.postbox.PostboxBlock;
 import com.simibubi.create.content.logistics.tableCloth.TableClothBlock;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import com.simibubi.create.infrastructure.ponder.AllCreatePonderTags;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.createmod.ponder.api.registration.*;
@@ -42,11 +41,6 @@ public class CSPonderPlugin implements PonderPlugin {
         helper.registerSharedText("movement_anchors", "With the help of Super Glue, larger structures can be moved.");
         helper.registerSharedText("behaviour_modify_value_panel", "This behaviour can be modified using the value panel");
         helper.registerSharedText("storage_on_contraption", "Inventories attached to the Contraption will pick up their drops automatically");
-    }
-
-    @Override
-    public void onPonderLevelRestore(PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
     }
 
     @Override


### PR DESCRIPTION
`CSPonderPlugin#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted twice. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally instead of seperately and already been called by `CreatePonderPlugin`.

https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/342